### PR TITLE
Faster iron time

### DIFF
--- a/pyutil/portfolio/portfolio.py
+++ b/pyutil/portfolio/portfolio.py
@@ -330,3 +330,16 @@ class Portfolio(object):
     # def read_csv(folder):
     #     return Portfolio(prices=pd.read_csv(os.path.join(folder, "prices.csv"), index_col=0, parse_dates=True),
     #               weights=pd.read_csv(os.path.join(folder, "weights.csv"), index_col=0, parse_dates=True))
+
+if __name__ == "__main__":
+    idx = pd.DatetimeIndex(start=pd.Timestamp("2018-10-28"), periods=100, freq="D")
+    print(idx)
+
+    x = pd.Series(data=idx, index=idx)
+    print(x)
+
+    # monthly
+    print(sorted(x.groupby([idx.year, idx.month]).last().values))
+
+    # weekly
+    print(sorted(x.groupby(idx.map(lambda x: x.isocalendar()[0:2])).last().values))


### PR DESCRIPTION
Using groupby as opposed to iterating over the index. As in your original, it returns the most recent date as the last value even if it is not the end of the period. For example, if today is 1/16/19 the last value for both weekly and monthly resampling will be 1/16/19 which is the last day in the period but not necessarily the last day of the week or month.

My original version created a set first, this version does not. I've been trying to think of edge cases where it would return duplicates but cannot think of any. If it makes you more comfortable feel free to make it `sorted(list(set(...)))` or the less performant `.drop_duplicates()`.

Uses `isocalendar` as opposed to `idx.week` for edge cases involving the last day of the year being in the middle of the week.

If it's ever desired to use offsets replace `.last()` with `.nth(-n)`.